### PR TITLE
메일링 기능 추가

### DIFF
--- a/pyconkr/settings.py
+++ b/pyconkr/settings.py
@@ -204,7 +204,7 @@ SOCIALACCOUNT_FORMS = {
     'signup': 'user.forms.SocialSignupForm'
 }
 
-if os.getenv('EMAIL_HOST_USER_REPLY'):
+if os.getenv('EMAIL_HOST_USER_NO_REPLY'):
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
     EMAIL_USE_TLS = True
     EMAIL_HOST = os.getenv('EMAIL_HOST_NO_REPLY')

--- a/pyconkr/settings.py
+++ b/pyconkr/settings.py
@@ -204,14 +204,14 @@ SOCIALACCOUNT_FORMS = {
     'signup': 'user.forms.SocialSignupForm'
 }
 
-if os.getenv('EMAIL_HOST_USER'):
+if os.getenv('EMAIL_HOST_USER_REPLY'):
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
     EMAIL_USE_TLS = True
-    EMAIL_HOST = 'email-smtp.us-west-2.amazonaws.com'
-    EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER')
-    EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD')
+    EMAIL_HOST = os.getenv('EMAIL_HOST_NO_REPLY')
+    EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER_NO_REPLY')
+    EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD_NO_REPLY')
     EMAIL_PORT = 587
-    DEFAULT_FROM_EMAIL = 'PyCon Korea <pyconkr@pycon.kr>'
+    DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
 DOMAIN = ''
 
@@ -382,15 +382,3 @@ SASS_PROCESSOR_INCLUDE_FILE_PATTERN = r'^.+\.scss$'
 COMPRESS_PRECOMPILERS = (
     ('text/x-scss', 'django_libsass.SassCompiler'),
 )
-
-# MAILING
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = os.getenv('EMAIL_HOST')
-# EMAIL_HOST_USER = constance.config.EMAIL_HOST_USER
-# EMAIL_HOST_PASSWORD = constance.config.EMAIL_HOST_PASSWORD
-EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER')
-EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD')
-EMAIL_PORT = 587
-EMAIL_USE_TLS = True
-# DEFAULT_FROM_EMAIL = constance.config.EMAIL_HOST_USER
-DEFAULT_FROM_EMAIL = EMAIL_HOST_USER

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 appdirs==1.4.3
+astroid==2.4.2
 autopep8==1.5
 boto3==1.12.5
 botocore==1.15.5
@@ -6,6 +7,7 @@ certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
 Collectfast==2.0.1
+colorama==0.4.3
 defusedxml==0.6.0
 diff-match-patch==20181111
 Django==2.2.13
@@ -33,10 +35,13 @@ greenlet==0.4.15
 gunicorn==20.0.4
 iamport-rest-client==0.8.0
 idna==2.8
+isort==4.3.21
 jdcal==1.4.1
 jmespath==0.9.4
+lazy-object-proxy==1.4.3
 libsass==0.20.0
 MarkupPy==1.14
+mccabe==0.6.1
 microsofttranslator==0.8
 numpy==1.18.1
 oauthlib==3.1.0
@@ -50,6 +55,9 @@ polib==1.1.0
 psycopg2==2.8.4
 pycodestyle==2.5.0
 pycparser==2.19
+pylint==2.5.3
+pylint-django==2.0.15
+pylint-plugin-utils==0.6
 pyparsing==2.4.6
 python-dateutil==2.8.1
 python-gnupg==0.4.5
@@ -66,7 +74,10 @@ slacker==0.14.0
 sorl-thumbnail==12.6.3
 sqlparse==0.3.0
 tablib==1.1.0
+toml==0.10.1
+typed-ast==1.4.1
 typing-extensions==3.7.4.1
 urllib3==1.25.8
+wrapt==1.12.1
 xlrd==1.2.0
 xlwt==1.3.0

--- a/task-definition-dev.json
+++ b/task-definition-dev.json
@@ -53,8 +53,19 @@
       {
         "valueFrom": "EMAIL_HOST_PASSWORD",
         "name": "EMAIL_HOST_PASSWORD"
+      },
+      {
+        "valueFrom": "EMAIL_HOST_NO_REPLY",
+        "name": "EMAIL_HOST_NO_REPLY"
+      },
+      {
+        "valueFrom": "EMAIL_HOST_USER_NO_REPLY",
+        "name": "EMAIL_HOST_USER_NO_REPLY"
+      },
+      {
+        "valueFrom": "EMAIL_HOST_PASSWORD_NO_REPLY",
+        "name": "EMAIL_HOST_PASSWORD_NO_REPLY"
       }
-
     ],
     "essential": true,
     "memoryReservation": 1024,

--- a/task-definition.json
+++ b/task-definition.json
@@ -54,6 +54,18 @@
       {
         "valueFrom": "EMAIL_HOST_PASSWORD",
         "name": "EMAIL_HOST_PASSWORD"
+      },
+      {
+        "valueFrom": "EMAIL_HOST_NO_REPLY",
+        "name": "EMAIL_HOST_NO_REPLY"
+      },
+      {
+        "valueFrom": "EMAIL_HOST_USER_NO_REPLY",
+        "name": "EMAIL_HOST_USER_NO_REPLY"
+      },
+            {
+        "valueFrom": "EMAIL_HOST_PASSWORD_NO_REPLY",
+        "name": "EMAIL_HOST_PASSWORD_NO_REPLY"
       }
     ],
     "essential": true,


### PR DESCRIPTION
메일링 기능을 추가했습니다.

개발서버에서는 정상동작함을 확인했고,
Admin 페이지에서 제목과 내용, 전송대상을 지정하면 수신대상에게 메일이 전송됩니다.

하단에 기본값으로 입력된 내용(`PyCon Korea`)을 수정하면 수신자 메일함에서 표시되는 발신자명 을 수정할 수 있습니다.

리뷰 부탁드려요~~!!