### PR TITLE
BCC를 이용한 메일 대량전송 대응

### DIFF
--- a/mailing/signal.py
+++ b/mailing/signal.py
@@ -1,7 +1,8 @@
 import datetime
+import time
 
 from django.contrib.auth import get_user_model
-from django.core.mail import send_mail
+from django.core.mail import send_mail, send_mass_mail, EmailMessage
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -11,10 +12,6 @@ from user.models import Profile
 
 @receiver(post_save, sender=Mailing)
 def send_email_immediately(sender, instance, created, **kwargs):
-    # print('sender: ', sender)
-    # print('instance: ', instance)
-    # print('created: ', created)
-
     KST = datetime.timezone(datetime.timedelta(hours=9))
     now = datetime.datetime.now(tz=KST)
 
@@ -28,29 +25,25 @@ def send_email_immediately(sender, instance, created, **kwargs):
 
     if created is True:
         send_list = list()
+        temp = list()
 
         if send_to_participants == 'INFO':
-            send_list = [(m.email, m.username) for m in user_model.objects.all()]
+            send_list = [m.email for m in user_model.objects.all()]
         elif send_to_participants == 'AD':
-            send_list = [(m.user.email, m.user.username) for m in
-                         Profile.objects.filter(agreement_receive_advertising_info=True)]
+            send_list = [m.user.email for m in Profile.objects.filter(agreement_receive_advertising_info=True)]
 
         # TODO 뉴스레터
         if send_to_subscriber == 'YES':
             subscriber_list = []
             send_list = send_list + subscriber_list
 
-#        print('전송 목록:', send_list)
-
-        for email_info in send_list:
-            send_mail(
-                instance.title,          # 제목
-                instance.content,        # 내용
-                instance.sender_name,    # 보내는 이메일  (settings에 설정해서 작성안해도 됨)
-                [email_info[0]],                    # 받는 이메일 리스트
-                fail_silently=False,
-                html_message=instance.content
-            )
+        email = EmailMessage(
+            instance.title,
+            instance.content,
+            instance.sender_name,
+            [],
+            temp,
+        ).send(fail_silently=False)
 
         instance.send_successfully = True
         instance.save()

--- a/mailing/signal.py
+++ b/mailing/signal.py
@@ -20,12 +20,8 @@ def send_email_immediately(sender, instance, created, **kwargs):
     send_to_participants = instance.send_to
     send_to_subscriber = instance.send_to_newsletter_subscriber
 
-    print('참가자 전송 Flag:', send_to_participants)
-    print('구독자 전송 Flag:', send_to_subscriber)
-
     if created is True:
         send_list = list()
-        temp = list()
 
         if send_to_participants == 'INFO':
             send_list = [m.email for m in user_model.objects.all()]
@@ -41,10 +37,9 @@ def send_email_immediately(sender, instance, created, **kwargs):
             instance.title,
             instance.content,
             instance.sender_name,
-            [],
-            temp,
+            [],  # To
+            send_list,  # bcc
         ).send(fail_silently=False)
 
         instance.send_successfully = True
         instance.save()
-        print('메일전송완료')


### PR DESCRIPTION
처음에는 `send_mass_mail`로 변경을 시도했었는데, 그래도 1명당 1.5초 정도의 시간이 소요되었습니다.

그래서 말씀해주셨던 방법으로 BCC를 이용해서 한번에 전송요청하는 것으로 수정했습니다.

그래도 1인당 0.3~0.5초 정도는 소요되는 것으로 확인됩니다. (로컬에서 10명 기준 테스트)

## Your checklist for this pull request

> ⚠️ [파이콘 한국 Contributing Guide](./CONTRIBUTING.md)를 꼭 준수해주세요.

- [x] PR의 **compare branch를 master나 develop로 생성하지 않아야** 합니다. :smile:
- [x] PR의 **base branch는 develop으로 지정**해야 합니다.
- [x] Commit Message가 적절한지 확인해주세요

## Description

PR에 관한 설명을 상세히 적어주세요

Thank you ❤️
