### PR TITLE
페이지 우측에 상단 이동 버튼 추가

### DIFF
--- a/pyconkr/static/css/pyconkr-media.scss
+++ b/pyconkr/static/css/pyconkr-media.scss
@@ -246,6 +246,19 @@
       }
     }
   }
+
+  #to-top-btn {
+    bottom: 5rem;
+    span {
+      display: none;
+    }
+    border-radius: 100px;
+    &::before {
+      line-height: 0.7;
+      font-size: 1rem;
+      margin-right: 2px;
+    }
+  }
 }
 
 @media (max-width: 640px) {

--- a/pyconkr/static/css/pyconkr.scss
+++ b/pyconkr/static/css/pyconkr.scss
@@ -1492,3 +1492,27 @@ table#sun {
     }
   }
 }
+
+#to-top-btn {
+  display: none;
+  position: fixed;
+  flex-flow: column;
+  align-items: center;
+  justify-content: center;
+  bottom: 15rem;
+  right: 5%;
+  z-index: 99;
+  border: 2px #e7e7e7 solid;
+  background-color: white;
+  color: #47647D;
+  width: 3rem;
+  height: 3rem;
+
+  &::before {
+    font-family: FontAwesome;
+    content: "\f077";
+    width: 16px;
+    height: 12px;
+    line-height: 1;
+  }
+}

--- a/pyconkr/templates/footer.html
+++ b/pyconkr/templates/footer.html
@@ -1,7 +1,10 @@
 {% load staticfiles %}
 {% load i18n %}
 
+
+
 <footer class="text-center">
+    <button id="to-top-btn" onclick="toTopFunc()" title="TOP"><span>TOP</span></button>
     <div class="container">
         <h3>We are Pythonistas, {% trans "PyCon Korea 2020" %}</h3>
         <p>{% trans "PyCon Korea 2020 is a product of PyCon Korea Organizing Team." %}</p>
@@ -17,3 +20,22 @@
         </p>
     </div>
 </footer>
+
+<!-- for button to top -->
+<script>
+    btn = document.getElementById("to-top-btn");
+    const scrollFunc = () => {
+        if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
+            btn.style.display = "flex";
+        } else {
+            btn.style.display = "none";
+        }
+    };
+
+    window.onscroll = () => {scrollFunc()};
+
+    const toTopFunc = () => {
+        document.body.scrollTop = 0;  // For Safari
+        document.documentElement.scrollTop = 0;  // For Chrome, Firefox, IE
+    }
+</script>


### PR DESCRIPTION
## Your checklist for this pull request

> ⚠️ [파이콘 한국 Contributing Guide](./CONTRIBUTING.md)를 꼭 준수해주세요.

- PR의 **compare branch를 master나 develop로 생성하지 않아야** 합니다. :smile:
- PR의 **base branch는 develop으로 지정**해야 합니다.
- Commit message가 적절한지 확인해주세요.

## Description

- 모든 페이지 우측에 페이지 최상단으로 바로 이동할 수 있는 버튼을 추가합니다. (모바일 포함)
  - 모바일에서 시간표 등 페이지의 세로 길이가 너무 길어짐에 따라 추가함

Thank you ❤️
