### PR TITLE
시간표 공개 이후 Proposal을 수정할 수 없음

### DIFF
--- a/program/forms.py
+++ b/program/forms.py
@@ -142,8 +142,9 @@ class LightningTalkForm(forms.ModelForm):
 class ProgramUpdateForm(forms.ModelForm):
     class Meta:
         model = Proposal
-        fields = ('introduction', 'slide_url',)
+        fields = ('title', 'introduction', 'slide_url',)
         labels = {
+            'title': _('Proposal title (required)'),
             'introduction': _('발표 소개 문구'),
             'slide_url': _('발표 자료 URL'),
         }

--- a/program/views.py
+++ b/program/views.py
@@ -421,7 +421,7 @@ def edit_proposal_available_checker(request):
         print('CFP 제출 기간에는 수정 가능')
         flag = True
     # 발표 시간표 공개 후 불가능
-    elif now > schedule_open:
+    if now > schedule_open:
         print('발표 시간표 공개 후에는 수정 불가능, 발표 소개 업데이트 폼으로 수정 가능')
         flag = False
     return flag

--- a/program/views.py
+++ b/program/views.py
@@ -254,7 +254,7 @@ class ProposalDetail(DetailView):
         context = super(ProposalDetail, self).get_context_data(**kwargs)
         context['title'] = _("Proposal")
         context['proposal'] = Proposal.objects.get(user=self.request.user, id=self.kwargs['pk'])
-        context['EDIT_AVAILABLE'] = edit_proposal_available_checker(self.request)
+        context['is_editable'] = edit_proposal_available_checker(self.request)
         return context
 
 

--- a/program/views.py
+++ b/program/views.py
@@ -407,6 +407,7 @@ def edit_proposal_available_checker(request):
     cfp_close = constance.config.CFP_CLOSE.replace(tzinfo=KST)
     open_review_start = constance.config.OPEN_REVIEW_START.replace(tzinfo=KST)
     open_review_finish = constance.config.OPEN_REVIEW_FINISH.replace(tzinfo=KST)
+    schedule_open = constance.config.SCHEDULE_OPEN.replace(tzinfo=KST)
 
     # CFP 마감 후 오픈리뷰 시작 전
     if cfp_close < now < open_review_start and Proposal.objects.filter(user=request.user).exists():
@@ -419,6 +420,10 @@ def edit_proposal_available_checker(request):
     elif cfp_open < now < cfp_close:
         print('CFP 제출 기간에는 수정 가능')
         flag = True
+    # 발표 시간표 공개 후 불가능
+    elif now > schedule_open:
+        print('발표 시간표 공개 후에는 수정 불가능, 발표 소개 업데이트 폼으로 수정 가능')
+        flag = False
     return flag
 
 

--- a/program/views.py
+++ b/program/views.py
@@ -255,6 +255,9 @@ class ProposalDetail(DetailView):
         context['title'] = _("Proposal")
         context['proposal'] = Proposal.objects.get(user=self.request.user, id=self.kwargs['pk'])
         context['is_editable'] = edit_proposal_available_checker(self.request)
+
+        KST, now = get_KST_now()
+        context['introduction_editable'] = now > constance.config.SCHEDULE_OPEN
         return context
 
 

--- a/pyconkr/templates/pyconkr/proposal_detail.html
+++ b/pyconkr/templates/pyconkr/proposal_detail.html
@@ -37,6 +37,9 @@
             {% if is_editable %}
                 <a class="a_btn" href="{% url 'proposal-update' proposal.id %}">{% trans "수정하기" %}</a>
             {% endif %}
+            {% if introduction_editable %}
+                <a class="a_btn" href="{% url 'talk-update' proposal.id %}">{% trans "발표 소개 수정하기" %}</a>
+            {% endif %}
         </div>
 </div>
 {% endblock %}

--- a/pyconkr/templates/pyconkr/proposal_detail.html
+++ b/pyconkr/templates/pyconkr/proposal_detail.html
@@ -34,7 +34,7 @@
         </div>
         <div class="a_btn_container">
             <a class="a_btn" href="{% url 'proposal-list' %}">{% trans "목록 보기" %}</a>
-            {% if EDIT_AVAILABLE %}
+            {% if is_editable %}
                 <a class="a_btn" href="{% url 'proposal-update' proposal.id %}">{% trans "수정하기" %}</a>
             {% endif %}
         </div>


### PR DESCRIPTION
## Your checklist for this pull request

> ⚠️ [파이콘 한국 Contributing Guide](./CONTRIBUTING.md)를 꼭 준수해주세요.

- PR의 **compare branch를 master나 develop로 생성하지 않아야** 합니다. :smile:
- PR의 **base branch는 develop으로 지정**해야 합니다.
- Commit message가 적절한지 확인해주세요.

## Description

### Program
- 발표 시간표 공개 이후 proposal update form에 접근할 수 없습니다.
  - 시간표 공개 이후 후원사 세션, 파준위 세션, 라톡, 오프닝, 클로징이 추가되기 때문에
  - Visible하지 않은 category가 계속 초기화 되는 현상 때문에 접근을 막습니다.
  - Category는 admin에서 수정합니다.
- 대신 발표 소개 수정 폼에서 발표 제목을 수정할 수 있습니다.


Thank you ❤️
